### PR TITLE
Hotfix Non-Serialized InstructorFallback object and multi-teacher objects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,5 @@
 	"discord.detailsIdle": "Takin a snooze or staring into exams.. .",
 	"discord.lowerDetailsIdle": "🍃",
 	"discord.detailsDebugging": "Debugging HuskyAPI Web Scraper 🌠",
-	"discord.lowerDetailsDebugging": "Debugging {filename}. Will they succeed? 🙀",
+	"discord.lowerDetailsDebugging": "Debugging {filename}. Will they succeed? 🙀"
 }

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -152,9 +152,6 @@ class Course(object):
             instructor = requests.get(
                 'http://www.uwfaculty-lmao.tk/faculty/api/v1/'
                 + first_name + " " + last_name)
-        if '"error":"Bad request"' in instructor.text and len(first_name) > 1:
-            instructor = requests.get(
-                'http://www.uwfaculty-lmao.tk/faculty/api/v1/' + first_name)
 
         if instructor.status_code > 200 or \
                 '"error":"Bad request"' in instructor.text:

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -158,7 +158,8 @@ class Course(object):
 
         if instructor.status_code > 200 or \
                 '"error":"Bad request"' in instructor.text:
-            instructor = InstructorFallback(first_name, middle_name, last_name)
+            instructor = InstructorFallback(
+                first_name, middle_name, last_name).__dict__
         else:
             instructor = instructor.json()
 


### PR DESCRIPTION

# Description

Fixes the scraper crashing whenever an InstructorFallback needs to be created but isn't serialized into the course info JSON once finished.

Also fixes multiple teachers appearing per course.

# How has this been tested?

Ran 'main.py' to it's entirety

# Checklist

- [ ] I have selected someone as a reviewer for this pull request.
- [ ] I have merged the latest version of `master` into my branch or repository fork.
- [ ] I have named my pull request "HUSKY-##: <Pull Request Description>"
- [ ] I have commented my code, if needed.
- [ ] I have added tests to prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
