### PR TITLE
HUSKY-31: Enhanced parsing alg, split to get more props

### DIFF
--- a/scraper/course.py
+++ b/scraper/course.py
@@ -5,8 +5,8 @@ from scraper.instructor import retrieve_instructor_object
 from scraper.room import parse_location
 from scraper.special import parse_special_types
 
-LIMITS = (7, 6, 3, 8, 18, 14, 27, 9, 9, 9, 5, 6)
-LENGTHS = [0, 7, 13, 16, 24, 42, 56, 83, 92, 101, 110, 115, 121]
+LIMITS = (7, 6, 3, 8, 18, 14, 27, 9, 8, 9, 5, 6)
+LENGTHS = [0, 7, 13, 16, 24, 42, 56, 83, 92, 100, 110, 115, 121]
 
 
 class ComplexEncoder(json.JSONEncoder):
@@ -143,9 +143,9 @@ class Course():
                 split_enroll[1] = split_enroll[1].replace(code, "")
             try:
                 self.currently_enrolled = int(split_enroll[0])
+                self.enrollment_limit = int(split_enroll[1])
             except ValueError:
                 return
-            self.enrollment_limit = int(split_enroll[1])
         else:
             self.currently_enrolled = 0
             self.enrollment_limit = 0

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -67,6 +67,7 @@ class Course():
         self.quarter, self.year, = quarter, year
 
     def parse_main_row(self, fields):
+        print(fields)
         """
         Parses the main row text of a course section table
         from the UW Time Schedule.
@@ -89,6 +90,15 @@ class Course():
             self.instructor = 'No instructor assigned.'
         else:
             self.instructor = retrieve_instructor_object(self.instructor)
+
+        if "" in fields[7]:
+            split_nit_combo = fields.pop(6).split()
+            split_nit_combo.reverse()
+            for attr in split_nit_combo:
+                fields.insert(6, attr)
+            fields[8] = fields[8] + fields[9]
+            fields.pop(9)
+
         self.status = fields[7]
         split_enroll = fields[8].replace(" ", "").split("/")
         self.parse_enrollment(split_enroll)
@@ -131,7 +141,10 @@ class Course():
         if len(split_enroll) > 1:
             for code in enrollment_codes:
                 split_enroll[1] = split_enroll[1].replace(code, "")
-            self.currently_enrolled = int(split_enroll[0])
+            try:
+                self.currently_enrolled = int(split_enroll[0])
+            except ValueError:
+                return
             self.enrollment_limit = int(split_enroll[1])
         else:
             self.currently_enrolled = 0

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -101,7 +101,7 @@ class Course():
         """
         if "" in fields[7] or "CR/NC" in fields[7]:
             split_nit_combo = fields.pop(6).split()
-            if split_nit_combo[1] is "" and len(split_nit_combo) > 2:
+            if split_nit_combo[1] == "" and len(split_nit_combo) > 2:
                 # Splits names like "LUFFY MONKEY D."
                 split_nit_combo[0] = split_nit_combo[0] + split_nit_combo[2]
                 split_nit_combo.remove(split_nit_combo[1])

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -37,7 +37,7 @@ class Course():
         self.currently_enrolled = ""
         self.instructor = ""
         self.status = ""
-        self.is_crnc = ""
+        self.is_crnc = False
         self.course_fee = ""
         self.special_type = ""
 
@@ -79,32 +79,68 @@ class Course():
         meeting_times = ' '.join(fields[4].split())
         self.parse_meeting_times(meeting_times)
 
+        # Checks if there's a 'status' inside the field where it's usually in
+
         self.room = parse_location(fields[5])
+
         pos = 0
         if "Open" in fields[6]:
             pos = fields[6].index("Open")
         elif "Closed" in fields[6]:
             pos = fields[6].index("Closed")
+
         self.instructor = ' '.join(fields[6][0:pos].split()) if pos != 0 else fields[6]
         if len(self.instructor) == 0:
             self.instructor = 'No instructor assigned.'
         else:
             self.instructor = retrieve_instructor_object(self.instructor)
 
-        if "" in fields[7]:
+        """
+            Splits fields with info in the format: "SHOOPA,M    Closed    1/ 42'
+            To: ["SHOOPA, M", Closed, and "1/  42"]
+            and appends them in the right order of 'fields'
+        """
+        if "" in fields[7] or "CR/NC" in fields[7]:
             split_nit_combo = fields.pop(6).split()
             split_nit_combo.reverse()
             for attr in split_nit_combo:
                 fields.insert(6, attr)
             fields[8] = fields[8] + fields[9]
             fields.pop(9)
+            if not self.status_in_right_field(fields, 7):
+                fields.insert(7, "")
 
         self.status = fields[7]
         split_enroll = fields[8].replace(" ", "").split("/")
+        self.split_joined_enroll_crnr(fields)
         self.parse_enrollment(split_enroll)
-        self.is_crnc = fields[9]
+        self.is_crnc = self.check_for_crnc(fields)
         self.course_fee = fields[10]
-        self.special_type = parse_special_types(fields[11])
+        try:
+            self.special_type = parse_special_types(fields[11])
+        except IndexError:
+            self.special_type = ""
+
+    def status_in_right_field(self, fields, num):
+        return "Open" in fields[num] or "Closed" in fields[num]
+
+    def split_joined_enroll_crnr(self, fields):
+        # Splits fields like " 1/ 42CR/NC"
+        if "CR/NC" in fields[8]:
+            fields[8] = fields[8].replace("CR/NC", "")
+            fields.insert(9, "CR/NC")
+            fields.remove(fields[10])
+
+    def check_for_crnc(self, fields):
+        if "CR/NC" in fields[9]:
+            return True
+
+        # Combines the course fee text in case of no 'CR/NC'.
+        if "$" in fields[9]:
+            fields.insert(9, False)
+            fields[10] = fields[10] + fields[11]
+            fields.remove(fields[11])
+            return False
 
     def parse_meeting_times(self, meeting_times):
         """

--- a/scraper/course.py
+++ b/scraper/course.py
@@ -5,8 +5,8 @@ from scraper.instructor import retrieve_instructor_object
 from scraper.room import parse_location
 from scraper.special import parse_special_types
 
-LIMITS = (7, 6, 3, 8, 18, 14, 27, 9, 8, 9, 5, 6)
-LENGTHS = [0, 7, 13, 16, 24, 42, 56, 83, 92, 100, 110, 115, 121]
+LIMITS = (7, 6, 3, 8, 18, 14, 27, 9, 9, 9, 5, 6)
+LENGTHS = [0, 7, 13, 16, 24, 42, 56, 83, 92, 101, 110, 115, 121]
 
 
 class ComplexEncoder(json.JSONEncoder):
@@ -67,7 +67,6 @@ class Course():
         self.quarter, self.year, = quarter, year
 
     def parse_main_row(self, fields):
-        print(fields)
         """
         Parses the main row text of a course section table
         from the UW Time Schedule.
@@ -102,6 +101,11 @@ class Course():
         """
         if "" in fields[7] or "CR/NC" in fields[7]:
             split_nit_combo = fields.pop(6).split()
+            if split_nit_combo[1] is "" and len(split_nit_combo) > 2:
+                # Splits names like "LUFFY MONKEY D."
+                split_nit_combo[0] = split_nit_combo[0] + split_nit_combo[2]
+                split_nit_combo.remove(split_nit_combo[1])
+                split_nit_combo.remove(split_nit_combo[1])
             split_nit_combo.reverse()
             for attr in split_nit_combo:
                 fields.insert(6, attr)

--- a/scraper/instructor.py
+++ b/scraper/instructor.py
@@ -25,7 +25,7 @@ def retrieve_instructor_object(instructor_name):
     instructor_name.replace(' ', '%20').replace(',', ' ')
     instructor_name_tokens = instructor_name.split(',')
     if len(instructor_name_tokens) > 1:
-        first_name = instructor_name_tokens[1].split(' ')
+        first_name = instructor_name_tokens[1].split(' ')[0]
     else:
         return ""
     if len(first_name) > 1:


### PR DESCRIPTION

# Description

Catches more cases of the parser not splitting the below into their right places:

- Status
- Enrollment numbers
- CR/NC
- Course Fee
- Special Type null catching

# How has this been tested?

Ran main.py to pop and look at some samples. Here are two of them:

![image](https://user-images.githubusercontent.com/6378303/93007154-40014000-f51a-11ea-98b0-40074db24384.png)

![image](https://user-images.githubusercontent.com/6378303/93007162-67f0a380-f51a-11ea-8cc2-a2474636858b.png)



# Checklist

- [ ] I have selected someone as a reviewer for this pull request.
- [ ] I have merged the latest version of `master` into my branch or repository fork.
- [ ] I have named my pull request "HUSKY-##: <Pull Request Description>"
- [ ] I have commented my code, if needed.
- [ ] I have added tests to prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation
